### PR TITLE
Update server port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ cd truco-online
 cd backend
 npm install && npm start
 ```
+Se precisar alterar a porta padrão (3000), defina a variável `PORT` antes de iniciar o servidor. Exemplo:
+
+```bash
+PORT=4000 npm start
+```
 
 ### 3. Rodar o Frontend Flutter
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -40,6 +40,7 @@ io.on('connection', (socket) => {
     });
 });
 
-server.listen(3000, () => {
-    console.log('Servidor rodando na porta 3000');
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+    console.log(`Servidor rodando na porta ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- make server port configurable via `process.env.PORT`
- document how to set `PORT`

## Testing
- `npm test` (fails: missing script)
- `flutter test` (fails: `flutter` not found)


------
https://chatgpt.com/codex/tasks/task_e_6858ee410590832e97c862427a5a64bc