### PR TITLE
Implement bot support with Socket.IO

### DIFF
--- a/backend/bot.js
+++ b/backend/bot.js
@@ -1,0 +1,30 @@
+const io = require('socket.io-client');
+
+const roomName = process.argv[2] || 'sala-bot';
+const username = process.argv[3] || 'Bot';
+
+const socket = io('http://localhost:3000', {
+    transports: ['websocket'],
+});
+
+let hand = [];
+
+socket.on('connect', () => {
+    console.log(`Bot conectado: ${socket.id}`);
+    socket.emit('joinRoom', { roomName, username });
+});
+
+socket.on('hand', (data) => {
+    if (data.player === username) {
+        hand = data.hand;
+        console.log('Mão recebida:', hand);
+    }
+});
+
+socket.on('suaVez', () => {
+    if (hand.length === 0) return;
+    const index = Math.floor(Math.random() * hand.length);
+    const card = hand.splice(index, 1)[0];
+    console.log('Jogando carta', card);
+    socket.emit('jogarCarta', { roomName, username, card });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "socket.io": "^4.8.1"
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -243,6 +244,36 @@
       },
       "engines": {
         "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -947,6 +978,38 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -1118,6 +1181,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,8 +2,9 @@
   "name": "backend",
   "version": "1.0.0",
   "main": "index.js",
-"scripts": {
-  "start": "node src/server.js"
+  "scripts": {
+    "start": "node src/server.js",
+    "bot": "node bot.js"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
   }
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:socket_io_client/socket_io_client.dart' as IO;
+import 'dart:io';
 import 'room_page.dart';
 
 void main() {
@@ -98,6 +99,27 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> playAgainstBot() async {
+    final roomName =
+        roomController.text.isNotEmpty ? roomController.text : 'sala-bot';
+
+    socket.emit('createRoom', roomName);
+    socket.emit('joinRoom', {
+      'roomName': roomName,
+      'username': 'jogador',
+    });
+
+    await Process.start('node', ['../backend/bot.js', roomName, 'Bot']);
+    socket.emit('startGame', roomName);
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => RoomPage(roomName: roomName, socket: socket),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -123,6 +145,11 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: joinRoom,
               child: const Text('Entrar na Sala'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: playAgainstBot,
+              child: const Text('Jogar contra Bot'),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add socket.io client bot script for automatic play
- install socket.io-client dependency
- expose new npm script to run the bot
- add a button in Flutter app to launch a game against the bot

## Testing
- `npm run --silent --prefix backend start` *(fails: stays running)*
- `node backend/bot.js testRoom Bot` *(terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_6858f10eb2c0832e8acfaa831830cf4c