### PR TITLE
Add basic GameScreen for Truco

### DIFF
--- a/frontend/lib/game_screen.dart
+++ b/frontend/lib/game_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:socket_io_client/socket_io_client.dart' as IO;
+
+class GameScreen extends StatefulWidget {
+  final IO.Socket socket;
+  final String playerName;
+  final String roomCode;
+
+  const GameScreen({super.key, required this.socket, required this.playerName, required this.roomCode});
+
+  @override
+  State<GameScreen> createState() => _GameScreenState();
+}
+
+class _GameScreenState extends State<GameScreen> {
+  List<Map<String, dynamic>> hand = [];
+  bool isMyTurn = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    widget.socket.on('cartasIniciais', _onInitialCards);
+    widget.socket.on('hand', _onHand); // suporte ao backend existente
+    widget.socket.on('suaVez', _onYourTurn);
+  }
+
+  void _onInitialCards(dynamic data) {
+    setState(() {
+      hand = List<Map<String, dynamic>>.from(data as List);
+    });
+  }
+
+  void _onHand(dynamic data) {
+    if (data is Map && data['player'] == widget.playerName) {
+      setState(() {
+        hand = List<Map<String, dynamic>>.from(data['hand'] as List);
+      });
+    }
+  }
+
+  void _onYourTurn(dynamic _) {
+    setState(() {
+      isMyTurn = true;
+    });
+  }
+
+  void playCard(Map<String, dynamic> card) {
+    widget.socket.emit('jogarCarta', {
+      'roomName': widget.roomCode,
+      'username': widget.playerName,
+      'card': card,
+    });
+    setState(() {
+      hand.removeWhere(
+        (c) => c['suit'] == card['suit'] && c['rank'] == card['rank'],
+      );
+      isMyTurn = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.socket.off('cartasIniciais', _onInitialCards);
+    widget.socket.off('hand', _onHand);
+    widget.socket.off('suaVez', _onYourTurn);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Jogo de Truco'),
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 20),
+          if (!isMyTurn) const Text('Aguardando sua vez...'),
+          Wrap(
+            spacing: 8,
+            children: hand
+                .map(
+                  (card) => ElevatedButton(
+                    onPressed: isMyTurn ? () => playCard(card) : null,
+                    child: Text('${card['rank']} de ${card['suit']}'),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:socket_io_client/socket_io_client.dart' as IO;
 import 'dart:io';
 import 'room_page.dart';
+import 'game_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -115,7 +116,11 @@ class _HomePageState extends State<HomePage> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => RoomPage(roomName: roomName, socket: socket),
+        builder: (context) => GameScreen(
+          socket: socket,
+          playerName: 'jogador',
+          roomCode: roomName,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- create GameScreen widget to display player hand and handle socket events
- link playAgainstBot() to new GameScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fae616f8832e929b667968ba8daf