### PR TITLE
Add random name for bot match

### DIFF
--- a/frontend/lib/game_screen.dart
+++ b/frontend/lib/game_screen.dart
@@ -71,7 +71,7 @@ class _GameScreenState extends State<GameScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Jogo de Truco'),
+        title: Text('Jogo de Truco - ${widget.playerName}'),
       ),
       body: Column(
         children: [

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:socket_io_client/socket_io_client.dart' as IO;
 import 'dart:io';
 import 'dart:async';
+import 'dart:math';
 import 'room_page.dart';
 import 'game_screen.dart';
 
@@ -119,14 +120,15 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> playAgainstBot() async {
-    final roomName =
-        roomController.text.isNotEmpty ? roomController.text : 'sala-bot';
+    final random = Random();
+    final roomName = 'sala-bot-${random.nextInt(1 << 32)}';
+    final playerName = 'Jogador${random.nextInt(1000)}';
 
     await _ensureConnected();
     socket.emit('createRoom', roomName);
     socket.emit('joinRoom', {
       'roomName': roomName,
-      'username': 'jogador',
+      'username': playerName,
     });
 
     void startGameListener(dynamic username) {
@@ -150,7 +152,7 @@ class _HomePageState extends State<HomePage> {
       MaterialPageRoute(
         builder: (context) => GameScreen(
           socket: socket,
-          playerName: 'jogador',
+          playerName: playerName,
           roomCode: roomName,
         ),
       ),


### PR DESCRIPTION
## Summary
- generate random room and nickname when playing against bot
- display player name in game title bar

## Testing
- `bash -lc 'flutter --version'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859067a6400832e82fef2544def32aa